### PR TITLE
Bonsai elastic search

### DIFF
--- a/config/initializers/elasticsearch.rb
+++ b/config/initializers/elasticsearch.rb
@@ -1,0 +1,12 @@
+config = {
+  host: ENV["BONSAI_URL"],
+  transport_options: {
+    request: { timeout: 5 }
+  }
+}
+  
+if File.exists?("config/elasticsearch.yml")
+  config.merge!(YAML.load_file("config/elasticsearch.yml")[Rails.env].deep_symbolize_keys)
+end
+
+Elasticsearch::Model.client = Elasticsearch::Client.new(config)


### PR DESCRIPTION
DONE:
 - Elasticsearch points to bonsai service instead of 9200 port in our local machine or aws. As it was difficult to install it on aws that was the best choice. However, to use it locally everyone now needs an environment variable locally and a production one for aws.