### PR TITLE
search endpoint encoding httparty url

### DIFF
--- a/app/services/geocoding_service.rb
+++ b/app/services/geocoding_service.rb
@@ -45,7 +45,7 @@ class GeocodingService < ObjectService
   end
 
   def url
-    URI.encode("https://api.tomtom.com/search/2/search/#{@text}.json")
+    "https://api.tomtom.com/search/2/search/#{CGI.escape(@text)}.json"
   end
 
   def clean_locations_response(dirty_locations)


### PR DESCRIPTION
GeocodingService now encodes the URL before requesting tomtom using HTTParty. This fixes errors like having space in the text query param (i.e: Balmes, Barcelona). Therefore, when requesting TomTom Api with text  'Balmes, Barcelona', the request will be executed with the text param being like 'Balmes,%20Barcelona'. 